### PR TITLE
misfit bug

### DIFF
--- a/pyrocko/trace.py
+++ b/pyrocko/trace.py
@@ -1013,11 +1013,12 @@ class Trace(object):
                     except UnavailableDecimation:
                             logger.warning('Cannot downsample reference trace. Make sure, that all ' \
                                     'candidates can be downsampled to sampling rate of this ' \
-                                    'trace (deltat=%s) et vice versai. m=None, n=None' % self.deltat)
+                                    'trace (deltat=%s) et vice versa. m=None, n=None' % self.deltat)
                             m.append(None)
                             n.append(None)
                             continue
-
+                    
+                    reference_trace.snap()
                     reference_trace.extend(tmin=wanted_tmin,
                                          tmax=wanted_tmax,
                                          fillmethod='repeat')


### PR DESCRIPTION
The additional Exception gives the programmer a little more clarity if the misfit fails in the corresponding case. 
The additional snap is needed if the misfit routine requires a fresh copy of self, for example, if tmin of the former candidate was smaller than the current candidate's tmin. 
