### PR TITLE
PoleZeroResponse: poles and zeros default-> empty list

### DIFF
--- a/pyrocko/trace.py
+++ b/pyrocko/trace.py
@@ -2008,8 +2008,8 @@ class PoleZeroResponse(FrequencyResponse):
     The poles and zeros should be given as angular frequencies, not in Hz.
     '''
     
-    zeros = List.T(Complex.T())
-    poles = List.T(Complex.T())
+    zeros = List.T(Complex.T(), optional=True, default=[()])
+    poles = List.T(Complex.T(), optional=True, default=[()])
     constant = Complex.T()
 
     def __init__(self, zeros, poles, constant):


### PR DESCRIPTION
If zeros or poles was an empty list it woudn't be listed in the concerning yaml dump at all, causing guts.load_string() to raise an exception. The default=[()] solves this. 
