### PR TITLE
Exception falls GMTHOME nicht definiert

### DIFF
--- a/src/gmtpy.py
+++ b/src/gmtpy.py
@@ -833,9 +833,11 @@ def detect_gmt_installation():
 
     if not output:
         raise ValueError("Can't find GMT installation via PATH")
-
     gmtbin = os.path.dirname(output)
-    gmthome = os.environ['GMTHOME']  # should throw a KeyError if not satisfied
+    try:
+        gmthome = os.environ['GMTHOME']  # should throw a KeyError if not satisfied
+    except KeyError:
+        raise Exception('GMTHOME environment variable undefinded')
 
     gmtversion = get_gmt_version(pjoin(gmtbin, 'gmtdefaults'), gmthome)
     return gmtversion, gmthome, gmtbin

--- a/src/gui_util.py
+++ b/src/gui_util.py
@@ -628,6 +628,9 @@ class Marker(object):
         '''
         return self.nslc_ids
 
+    def get_event(self):
+        return None
+
     def is_alerted(self):
         return self.alerted
         
@@ -890,7 +893,7 @@ class EventMarker(Marker):
     def set_active(self, active):
         self._active = active
 
-    def label(self):
+    def get_label(self):
         t = []
         mag = self._event.magnitude
         if mag is not None:
@@ -918,7 +921,7 @@ class EventMarker(Marker):
         u = time_projection(self.tmin)
         v0, v1 = y_projection.get_out_range()
         label_bg = QBrush( QColor(255,255,255) )
-        draw_label( p, u, v0-10., self.label(), label_bg, 'CB', outline=self._active)
+        draw_label( p, u, v0-10., self.get_label(), label_bg, 'CB', outline=self._active)
 
     def get_event(self):
         '''Return an instance of the :py:class:`pyrocko.model.Event` associated


### PR DESCRIPTION
installiert man gmt4 wird nicht darauf hingewiesen, dass man auch GMTHOME definieren muss, sondern nur dass PATH angepasst werden soll. GMT funktioniert dann auch so, allerdings verweigert automap seine Dienste. Mit der hinzugefuegten Exception wird man das Problem denke ich wesentlich schneller finden. 
Der andere commit lebte urspruenglich in einem anderen branch, kann aber eigentlich auch gleich mit gemergt werden. get_event() ist ganz convenient bei meiner aktuellen MarkerMenuAufbohrung. get_label ist analog umbenannt zum get_label des Markers/PhaseMarkers. 
