### PR TITLE
fix Srtmgl3 (recently broken due to authentication)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -4,7 +4,8 @@ import os.path as op
 from copy import deepcopy
 
 from pyrocko import util
-from pyrocko.guts import Object, Float, String, load, dump, List, Dict, TBase
+from pyrocko.guts import Object, Float, String, load, dump, List, Dict, \
+    TBase, Tuple
 
 guts_prefix = 'pf'
 
@@ -81,6 +82,7 @@ class PyrockoConfig(ConfigBase):
         default=os.path.join(pyrocko_dir_tmpl, 'leap-seconds.list'))
     leapseconds_url = String.T(
         default='http://www.ietf.org/timezones/data/leap-seconds.list')
+    earthdata_credentials = Tuple.T(2, String.T(), optional=True)
 
 
 config_cls = {

--- a/src/topo/dataset.py
+++ b/src/topo/dataset.py
@@ -58,8 +58,8 @@ class TiledGlobalDataset(object):
         d = 360. / (self.nx - 1)
         return self.covers(region) and dmin <= d <= dmax
 
-    def download_file(self, url, fpath):
-        util.download_file(url, fpath)
+    def download_file(self, url, fpath, username=None, password=None):
+        util.download_file(url, fpath, username, password)
 
     def x(self):
         return self.xmin + num.arange(self.nx) * self.dx

--- a/src/topo/srtmgl3.py
+++ b/src/topo/srtmgl3.py
@@ -25,6 +25,10 @@ Rosen, P. A. et al., 2000, Synthetic aperture radar interferometry, Proc. IEEE,
 '''
 
 
+class AuthenticationRequired(Exception):
+    pass
+
+
 class SRTMGL3(dataset.TiledGlobalDataset):
 
     def __init__(
@@ -100,7 +104,12 @@ class SRTMGL3(dataset.TiledGlobalDataset):
         if self.config.earthdata_credentials:
             cred = self.config.earthdata_credentials
         else:
-            cred = (None, None)
+            raise AuthenticationRequired(
+                '\n\nRegister at https://urs.earthdata.nasa.gov/users/new ' +
+                'and provide credentials in your local ~/.pyrocko/config.pf ' +
+                'as follows:\n' +
+                'earthdata_credentials: [username, password]')
+
         self.download_file(url, fpath, *cred)
 
     def download(self):

--- a/src/topo/srtmgl3.py
+++ b/src/topo/srtmgl3.py
@@ -6,7 +6,7 @@ import re
 
 import numpy as num
 
-from pyrocko import util
+from pyrocko import util, config
 from pyrocko.topo import tile, dataset
 
 citation = '''
@@ -45,6 +45,7 @@ class SRTMGL3(dataset.TiledGlobalDataset):
 
         self.raw_data_url = raw_data_url
         self._available_tilenames = None
+        self.config = config.config()
 
     def tilename(self, itx, ity):
         itx -= 180
@@ -96,7 +97,11 @@ class SRTMGL3(dataset.TiledGlobalDataset):
         fpath = self.tilepath(tilename)
         fn = self.tilefilename(tilename)
         url = self.raw_data_url + '/' + fn
-        self.download_file(url, fpath)
+        if self.config.earthdata_credentials:
+            cred = self.config.earthdata_credentials
+        else:
+            cred = (None, None)
+        self.download_file(url, fpath, *cred)
 
     def download(self):
         for tn in self.available_tilenames():

--- a/src/util.py
+++ b/src/util.py
@@ -68,14 +68,21 @@ class DownloadError(Exception):
     pass
 
 
-def download_file(url, fpath):
+def download_file(url, fpath, username=None, password=None):
     import urllib2
+    import base64
 
     logger.info('starting download of %s' % url)
 
     ensuredirs(fpath)
     try:
-        f = urllib2.urlopen(url)
+        request = urllib2.Request(url)
+        if username and password:
+            base64string = base64.b64encode('%s:%s' % (username, password))
+            request.add_header("Authorization", "Basic %s" % base64string)
+
+        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor())
+        f = opener.open(request)
     except urllib2.HTTPError, e:
         raise DownloadError('cannot download file from url %s: %s' % (url, e))
 


### PR DESCRIPTION
Since recently, srtmgl3 is only accessible after having provided a username and password. 
One needs to create an account at https://urs.earthdata.nasa.gov/
These credentials can be filled in the pyrocko config file as follows:

        earthdata_credentials: [someusername, somepassword]

Maybe one should make this a little more secure, though... Opinions?