### PR TITLE
Fix memory leak in evalresp_ext

### DIFF
--- a/src/evalresp_ext.c
+++ b/src/evalresp_ext.c
@@ -27,7 +27,7 @@ evresp_wrapper (PyObject *dummy, PyObject *args)
     int listinterp_out_flag = 0, listinterp_in_flag = 0;
     double listinterp_tension = 1000.0;
     char *datime;
-    struct response *first;
+    struct response *first, *r;
 
     PyArrayObject *freqs_array = NULL, *freqs_array_cont = NULL;
     PyObject      *rvec_array = NULL;
@@ -86,20 +86,20 @@ evresp_wrapper (PyObject *dummy, PyObject *args)
     out_list = Py_BuildValue("[]");
 
 
-
-    while (first) {
+    r = first;
+    while (r) {
 
         array_dims[0] = nfreqs;
         rvec_array = PyArray_SimpleNew(1, array_dims, NPY_COMPLEX128);
-        memcpy( PyArray_DATA((PyArrayObject*)rvec_array), first->rvec, nfreqs*16 );
+        memcpy( PyArray_DATA((PyArrayObject*)rvec_array), r->rvec, nfreqs*16 );
 
         elem = Py_BuildValue("(s,s,s,s,N)",
-            first->station, first->network, first->locid, first->channel, rvec_array);
+            r->station, r->network, r->locid, r->channel, rvec_array);
 
         PyList_Append(out_list, elem);
         Py_DECREF(elem);
 
-        first = first->next;
+        r = r->next;
     }
     free_response(first);
 

--- a/src/evalresp_ext.c
+++ b/src/evalresp_ext.c
@@ -27,13 +27,13 @@ evresp_wrapper (PyObject *dummy, PyObject *args)
     int listinterp_out_flag = 0, listinterp_in_flag = 0;
     double listinterp_tension = 1000.0;
     char *datime;
-    struct response *first, *r;
-    
+    struct response *first;
+
     PyArrayObject *freqs_array = NULL, *freqs_array_cont = NULL;
     PyObject      *rvec_array = NULL;
     PyObject      *elem, *out_list;
     npy_intp      array_dims[1] = {0};
-    
+
     if (!PyArg_ParseTuple(args, "sssssssOssiiiiid",
                             &sta_list,
                             &cha_list,
@@ -56,12 +56,12 @@ evresp_wrapper (PyObject *dummy, PyObject *args)
                                        "listinterp_out_flag, listinterp_in_flag, listinterp_tension)" );
         return NULL;
     }
-    
+
     if (!PyArray_Check(freqs_array)) {
         PyErr_SetString(EvalrespError, "Frequencies must be given as NumPy array." );
         return NULL;
     }
-    
+
     assert( sizeof(double) == 8 );
     if (!PyArray_TYPE(freqs_array) == NPY_FLOAT64) {
         PyErr_SetString(EvalrespError, "Frequencies must be of type double.");
@@ -82,25 +82,25 @@ evresp_wrapper (PyObject *dummy, PyObject *args)
         PyErr_SetString(EvalrespError, "Function evresp() failed" );
         return NULL;
     }
-    
+
     out_list = Py_BuildValue("[]");
 
 
 
     while (first) {
-    
+
         array_dims[0] = nfreqs;
         rvec_array = PyArray_SimpleNew(1, array_dims, NPY_COMPLEX128);
         memcpy( PyArray_DATA((PyArrayObject*)rvec_array), first->rvec, nfreqs*16 );
-        
-        elem = Py_BuildValue("(s,s,s,s,N)",  
+
+        elem = Py_BuildValue("(s,s,s,s,N)",
             first->station, first->network, first->locid, first->channel, rvec_array);
-                
+
         PyList_Append(out_list, elem);
         Py_DECREF(elem);
-                
+
         first = first->next;
-    } 
+    }
     free_response(first);
 
     return out_list;
@@ -108,7 +108,7 @@ evresp_wrapper (PyObject *dummy, PyObject *args)
 
 
 static PyMethodDef EVALRESPMethods[] = {
-    {"evalresp",  evresp_wrapper, METH_VARARGS, 
+    {"evalresp",  evresp_wrapper, METH_VARARGS,
     "" },
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
@@ -124,7 +124,7 @@ initevalresp_ext(void)
     import_array();
 
     EvalrespError = PyErr_NewException("evalresp_ext.error", NULL, NULL);
-    Py_INCREF(EvalrespError);  /* required, because other code could remove `error` 
+    Py_INCREF(EvalrespError);  /* required, because other code could remove `error`
                                from the module, what would create a dangling
                                pointer. */
     PyModule_AddObject(m, "EvalrespError", EvalrespError);

--- a/src/evalresp_ext.c
+++ b/src/evalresp_ext.c
@@ -28,13 +28,13 @@ evresp_wrapper (PyObject *dummy, PyObject *args)
     double listinterp_tension = 1000.0;
     char *datime;
     struct response *first, *r;
-
+    
     PyArrayObject *freqs_array = NULL, *freqs_array_cont = NULL;
     PyObject      *rvec_array = NULL;
     PyObject      *elem, *out_list;
     npy_intp      array_dims[1] = {0};
-
-     if (!PyArg_ParseTuple(args, "sssssssOssiiiiid",
+    
+    if (!PyArg_ParseTuple(args, "sssssssOssiiiiid",
                             &sta_list,
                             &cha_list,
                             &net_code,
@@ -87,22 +87,21 @@ evresp_wrapper (PyObject *dummy, PyObject *args)
 
 
 
-    r = first;
-    while (r) {
+    while (first) {
     
         array_dims[0] = nfreqs;
         rvec_array = PyArray_SimpleNew(1, array_dims, NPY_COMPLEX128);
-        memcpy( PyArray_DATA((PyArrayObject*)rvec_array), r->rvec, nfreqs*16 );
+        memcpy( PyArray_DATA((PyArrayObject*)rvec_array), first->rvec, nfreqs*16 );
         
         elem = Py_BuildValue("(s,s,s,s,N)",  
-            r->station, r->network, r->locid, r->channel, rvec_array);
+            first->station, first->network, first->locid, first->channel, rvec_array);
                 
         PyList_Append(out_list, elem);
         Py_DECREF(elem);
                 
-        r = r->next;
+        first = first->next;
     } 
-    free_response(r);
+    free_response(first);
 
     return out_list;
 }

--- a/src/trace.py
+++ b/src/trace.py
@@ -2420,7 +2420,8 @@ class Evalresp(FrequencyResponse):
     Calls evalresp and generates values of the instrument response transfer
     function.
 
-    :param respfile: response file in evalresp format
+    :param respfile: response file or directory containing response files in
+        evalresp format
     :param trace: trace for which the response is to be extracted from the file
     :param target: ``'dis'`` for displacement or ``'vel'`` for velocity
     '''


### PR DESCRIPTION
Please check. evalresp_ext line 90 assigned r = first but first was not used afterwards neither deallocated, so I replaced r with first.

Includes also some cleanup.