### PR TITLE
argmax C implementation

### DIFF
--- a/src/parstack.py
+++ b/src/parstack.py
@@ -86,3 +86,10 @@ def parstack_numpy(
         return result, offsetout
     elif method == 1:
         return num.amax(result.reshape((nshifts, nsamp)), axis=1), offsetout
+
+
+def argmax(a):
+    '''Same as numpys' argmax for 2 dimensional arrays along axis 0
+    but more memory efficient and twice as fast.'''
+
+    return parstack_ext.argmax(a)

--- a/src/parstack_ext.c
+++ b/src/parstack_ext.c
@@ -191,16 +191,15 @@ int parstack(
 int argmax(double *arrayin, int *arrayout, npy_intp *shape){
     int m, n, im, in, imax, imm;
     double vmax;
-    n = shape[0];
-    m = shape[1];
+    n = shape[1];
+    m = shape[0];
 
-    for (in=0; in<m; in++){
+    for (in=0; in<n; in++){
         imax = 0;
         vmax = DBL_MIN;
-        for (im=0; im<n; im++){
-            imm = im * m;
-            if (arrayin[imm + in] > vmax){
-                vmax = arrayin[imm + in];
+        for (im=0; im<m; im++){
+            if (arrayin[im*n + in] > vmax){
+                vmax = arrayin[im*n + in];
                 imax = im;
             }
         }

--- a/test/test_parstack.py
+++ b/test/test_parstack.py
@@ -315,6 +315,14 @@ class ParstackTestCase(unittest.TestCase):
         axes.plot(source.east_shift/km, source.north_shift/km, 'o')
         plt.show()
 
+    def test_argmax(self):
+        from pyrocko.parstack import argmax as pargmax
+        import numpy as num
+        a = num.random.random((100, 1000))
+        argmax_numpy = num.argmax(a, axis=0)
+        argmax_parstack = pargmax(a)
+        num.testing.assert_array_equal(argmax_parstack, argmax_numpy)
+
 
 if __name__ == '__main__':
     util.setup_logging('test_parstack', 'warning')


### PR DESCRIPTION
This is about twice as fast and does not require a full memcopy to get a contiguous block of memory. Still, the strided memory access is the bottle neck in terms of performance, as it seems.