### PR TITLE
fix compiler warnings

### DIFF
--- a/src/parstack_ext.c
+++ b/src/parstack_ext.c
@@ -198,6 +198,7 @@ int argmax(double *arrayin, uint32_t *arrayout, size_t nx, size_t ny, int nparal
 
     size_t ix, iy, ix_offset, imax[NBLOCK];
     double vmax[NBLOCK];
+	(void) nparallel;
 
     Py_BEGIN_ALLOW_THREADS
 

--- a/src/util_ext.c
+++ b/src/util_ext.c
@@ -92,8 +92,8 @@ util_error_t stt(const char *s, const char *format, time_t *t, double *tfrac) {
     }
 
     if (nexpect != -2) {
-        *rindex(format2, '.') = '\0'; /* cannot fail here */
-        sfrac = rindex(s2, '.');
+        *strchr(format2, '.') = '\0'; /* cannot fail here */
+        sfrac = strchr(s2, '.');
         if (nexpect != 0 && sfrac == NULL) {
             return TIME_FORMAT_ERROR;  /* fractional seconds expected but not found */
         }


### PR DESCRIPTION
clang complained that rindex is deprecated. Replaced it. There is one more, though:

src/util_ext.c:120:10: warning: implicit declaration of function 'timegm' is invalid in C99
      [-Wimplicit-function-declaration]
    *t = timegm(&tm);

was it supposed to be replaced by my_timegm?

