### PR TITLE
ws: lower boolean query arguments

### DIFF
--- a/src/fdsn/ws.py
+++ b/src/fdsn/ws.py
@@ -167,7 +167,7 @@ def fix_params(d):
 
     for k in params:
         if isinstance(params[k], bool):
-            params[k] = ['FALSE', 'TRUE'][bool(params[k])]
+            params[k] = ['false', 'true'][bool(params[k])]
 
     return params
 


### PR DESCRIPTION
INGV requires lower case booleans. Do other services require upper case? Tests are ok. 