### PR TITLE
fomosto becomes more verbose

### DIFF
--- a/src/fomosto/qseis.py
+++ b/src/fomosto/qseis.py
@@ -749,15 +749,8 @@ class QSeisGFBuilder(gf.builder.Builder):
         deltat = 1.0/self.gf_config.sample_rate
 
         if 'time_window_min' not in shared:
-            try:
-                d = self.store.make_timing_params(
-                    conf.time_region[0], conf.time_region[1])
-            except gf.store.MakeTimingParamsFailed as e:
-                msg = 'Error setting up timing params using phase definitions: '
-                for tr in conf.time_region:
-                    msg += '\n  {}'.format(tr)
-                logger.error(msg)
-                raise e
+            d = self.store.make_timing_params(
+                conf.time_region[0], conf.time_region[1])
 
             shared['time_window_min'] = d['tlenmax_vred']
             shared['time_start'] = d['tmin_vred']

--- a/src/fomosto/qseis.py
+++ b/src/fomosto/qseis.py
@@ -749,8 +749,15 @@ class QSeisGFBuilder(gf.builder.Builder):
         deltat = 1.0/self.gf_config.sample_rate
 
         if 'time_window_min' not in shared:
-            d = self.store.make_timing_params(
-                conf.time_region[0], conf.time_region[1])
+            try:
+                d = self.store.make_timing_params(
+                    conf.time_region[0], conf.time_region[1])
+            except gf.store.MakeTimingParamsFailed as e:
+                msg = 'Error setting up timing params using phase definitions: '
+                for tr in conf.time_region:
+                    msg += '\n  {}'.format(tr)
+                logger.error(msg)
+                raise e
 
             shared['time_window_min'] = d['tlenmax_vred']
             shared['time_start'] = d['tmin_vred']

--- a/src/gf/builder.py
+++ b/src/gf/builder.py
@@ -4,6 +4,7 @@ import errno
 from os.path import join as pjoin
 import numpy as num
 
+from collections import defaultdict
 from pyrocko.gf import store
 from pyrocko.parimap import parimap
 
@@ -32,6 +33,7 @@ class Builder:
         self.step = step
         self.force = force
         self.gf_config = gf_config
+        self.warnings = defaultdict(int)
         self._block_size = int_arr(*block_size)
 
     @property
@@ -41,6 +43,16 @@ class Builder:
     @property
     def block_dims(self):
         return (self.gf_config.ns-1) / self._block_size + 1
+
+    def warn(self, msg):
+        self.warnings[msg] += 1
+
+    def log_warnings(self, index, logger):
+        for warning, noccur in self.warnings.items():
+            msg = "block {}: " + warning
+            logger.warn(msg.format(index, noccur))
+
+        self.warnings = defaultdict(int)
 
     def all_block_indices(self):
         return num.arange(self.nblocks)

--- a/src/gf/store.py
+++ b/src/gf/store.py
@@ -1612,16 +1612,20 @@ class Store(BaseStore):
         '''
 
         data = []
-        errmsg = ''
+        failed = []
         for args in self.config.iter_nodes(level=-1):
             tmin = self.t(begin, args)
             tmax = self.t(end, args)
             if not tmin:
-                errmsg += 'determination of time window failed (begin)'
+                failed.append(str(begin))
             if not tmax:
-                errmsg += 'determination of time window failed (end)'
-            if errmsg:
-                raise MakeTimingParamsFailed(errmsg)
+                failed.append(str(end))
+
+            if failed:
+                msg = 'determination of time window failed using phase ' +\
+                    'definitions: {}.\n Travel time table contains holes ' +\
+                    'in probed ranges.'
+                raise MakeTimingParamsFailed(msg.format(' and '.join(failed)))
 
             x = self.config.get_surface_distance(args)
             data.append((x, tmin, tmax))

--- a/src/gf/store.py
+++ b/src/gf/store.py
@@ -1417,6 +1417,14 @@ class Store(BaseStore):
     stats_keys = BaseStore.stats_keys + ['decimated']
 
     def check(self, show_progress=False):
+        for pdef in self.config.tabulated_phases:
+            phase_id = pdef.id
+            ph = self.get_stored_phase(phase_id)
+            if ph.check_holes():
+                logger.warn(
+                    'travel time table of phase "{}" contains holes'.format(
+                        phase_id))
+
         if show_progress:
             pbar = util.progressbar('checking store', self.config.nrecords)
 

--- a/src/gf/store.py
+++ b/src/gf/store.py
@@ -1612,9 +1612,17 @@ class Store(BaseStore):
         '''
 
         data = []
+        errmsg = ''
         for args in self.config.iter_nodes(level=-1):
             tmin = self.t(begin, args)
             tmax = self.t(end, args)
+            if not tmin:
+                errmsg += 'determination of time window failed (begin)'
+            if not tmax:
+                errmsg += 'determination of time window failed (end)'
+            if errmsg:
+                raise MakeTimingParamsFailed(errmsg)
+
             x = self.config.get_surface_distance(args)
             data.append((x, tmin, tmax))
 

--- a/src/spit.py
+++ b/src/spit.py
@@ -125,8 +125,14 @@ class Cell:
             points = num.transpose(points)
             axes.plot(points[1], points[0], color=(0.1, 0.1, 0.0, 0.1))
 
-    def plot_2d(self, axes, x, dims):
+    def check_holes(self):
+        ''' Check if :py:class:`Cell` or its' children contain NaNs'''
+        if self.children:
+            return any([child.check_holes() for child in self.children])
+        else:
+            return num.any(num.isnan(self.f))
 
+    def plot_2d(self, axes, x, dims):
         idims = num.array(dims)
         self.plot_rects(axes, x, dims)
         coords = [
@@ -147,9 +153,10 @@ class Cell:
         fi_r = fi.ravel()
         fi_r[...] = self.interpolate_many(points)
 
+        if num.any(num.isnan(fi)):
+            logger.warn('')
         if any_(num.isfinite(fi)):
             fi = num.ma.masked_invalid(fi)
-
             axes.imshow(
                 fi, origin='lower',
                 extent=[coords[1].min(), coords[1].max(),
@@ -413,6 +420,10 @@ class SPTree:
             self.ncells += 1
             cell.children.append(child)
             self._fill(child)
+
+    def check_holes(self):
+        '''Check for NaNs in :py:class:`SPTree`'''
+        return self.root.check_holes()
 
     def plot_2d(self, axes=None, x=None, dims=None):
         assert self.ndim >= 2


### PR DESCRIPTION
fomosto buiding with qseis will log warnings when time windows could not be estimated to chop traces. This was silently skipped before resulting in empty traces being inserted into the database.
e.g.

    fomosto:fomosto.qseis        - WARNING  - block 33: Failed cutting 42 traces. Failed to determine time window

Furthermore, 

    fomosto check

prints information on holes in travel time tables, which makes it easier to identify problems. 
e.g.:

    fomosto:pyrocko.gf.store     - WARNING  - travel time table of phase "begin" contains holes
