### PR TITLE
Marker with uncertainty

### DIFF
--- a/src/gui/marker.py
+++ b/src/gui/marker.py
@@ -19,8 +19,17 @@ from pyrocko.util import TableWriter, TableReader, gmtime_x, mystrftime
 
 logger = logging.getLogger('pyrocko.gui.marker')
 
+box_alpha = 40
+
 
 def str_to_float_or_none(s):
+    if s == 'None':
+        return None
+    else:
+        return float(s)
+
+
+def str_to_int_or_none(s):
     if s == 'None':
         return None
     else:
@@ -182,7 +191,7 @@ class Marker(object):
 
         return markers
 
-    def __init__(self, nslc_ids, tmin, tmax, kind=0, uncertainty=0.):
+    def __init__(self, nslc_ids, tmin, tmax, kind=0):
         self.set(nslc_ids, tmin, tmax)
         c = plot.color
 
@@ -200,7 +209,6 @@ class Marker(object):
         self.alerted = False
         self.selected = False
         self.kind = kind
-        self.uncertainty = uncertainty
 
     def set(self, nslc_ids, tmin, tmax):
         '''Set ``nslc_ids``, start time and end time of :py:class:`Marker`
@@ -394,8 +402,6 @@ class Marker(object):
 
             if draw_line or self.selected or self.alerted:
                 p.setPen(linepen)
-                drawline(self.tmin - self.uncertainty)
-                drawline(self.tmax + self.uncertainty)
                 drawline(self.tmin)
                 drawline(self.tmax)
 
@@ -499,7 +505,8 @@ class Marker(object):
             polarity=None,
             automatic=None,
             incidence_angle=None,
-            takeoff_angle=None):
+            takeoff_angle=None,
+            uncertainty=None):
 
         if isinstance(self, PhaseMarker):
             return
@@ -511,6 +518,7 @@ class Marker(object):
         self._automatic = automatic
         self._incidence_angle = incidence_angle
         self._takeoff_angle = takeoff_angle
+        self._uncertainty = uncertainty
         if self._event:
             self._event_hash = event.get_hash()
         else:
@@ -652,7 +660,6 @@ class EventMarker(Marker):
 
 
 class PhaseMarker(Marker):
-    polarity_symbols = {1: u'\u2191', -1:u'\u2193', None: u''}
     '''
     A PhaseMarker is a GUI-element representing a seismological phase arrival
 
@@ -673,6 +680,8 @@ class PhaseMarker(Marker):
     :param incident_angle: (optional) incident angle of phase
     :param takeoff_angle: (optional) take off angle of phase
     '''
+    polarity_symbols = {1: u'\u2191', -1: u'\u2193', None: u''}
+
     def __init__(
             self, nslc_ids, tmin, tmax,
             kind=0,
@@ -683,20 +692,41 @@ class PhaseMarker(Marker):
             polarity=None,
             automatic=None,
             incidence_angle=None,
-            takeoff_angle=None):
+            takeoff_angle=None,
+            uncertainty=None):
 
         Marker.__init__(self, nslc_ids, tmin, tmax, kind)
         self._event = event
         self._event_hash = event_hash
         self._event_time = event_time
         self._phasename = phasename
-        self._polarity = polarity
         self._automatic = automatic
         self._incidence_angle = incidence_angle
         self._takeoff_angle = takeoff_angle
+        self._uncertainty = uncertainty
+        self.set_polarity(polarity)
 
     def draw_trace(self, viewer, p, tr, time_projection, track_projection,
                    gain):
+
+        if self.nslc_ids and not self.match_nslc(tr.nslc_id):
+            return
+
+        from .qt_compat import qc, qg
+
+        color = self.select_color(self.color_b)
+
+        def draw_box(tmin, tmax):
+            fill_brush = qg.QBrush(qg.QColor(*color + (box_alpha, )))
+            p.setBrush(fill_brush)
+            dvmin, dvmax = track_projection.get_out_range()
+            dtmin = time_projection.clipped(tmin)
+            dtmax = time_projection.clipped(tmax)
+            rect = qc.QRectF(dtmin, dvmin, float(dtmax-dtmin), dvmax-dvmin)
+            p.fillRect(rect, fill_brush)
+
+        if self._uncertainty:
+            draw_box(self.tmin-self._uncertainty, self.tmax+self._uncertainty)
 
         Marker.draw_trace(
             self, viewer, p, tr, time_projection, track_projection, gain,
@@ -749,8 +779,8 @@ class PhaseMarker(Marker):
         self._phasename = phasename
 
     def set_polarity(self, polarity):
-        if polarity not in [1, -1, 0, None]:
-            raise ValueError('polarity has to be 1, -1, 0 or None')
+        if polarity not in [1, -1, None]:
+            raise ValueError('polarity has to be 1, -1 or None')
         self._polarity = polarity
 
     def get_polarity(self):
@@ -764,6 +794,7 @@ class PhaseMarker(Marker):
         del self._automatic
         del self._incidence_angle
         del self._takeoff_angle
+        del self._uncertainty
         self.__class__ = Marker
 
     def hoover_message(self):
@@ -789,27 +820,37 @@ class PhaseMarker(Marker):
             et = st(self._event.time).split()
 
         attributes.extend([
-            h, et[0], et[1], self._phasename, self._polarity, self._automatic])
+            h, et[0], et[1], self._phasename, self._polarity, self._automatic,
+            self._uncertainty])
         return attributes
 
     def get_attribute_widths(self, fdigits=3):
         ws = [6]
         ws.extend(Marker.get_attribute_widths(self, fdigits=fdigits))
-        ws.extend([14, 12, 12, 8, 4, 5])
+        ws.extend([14, 12, 12, 8, 4, 5, 5])
         return ws
 
     @staticmethod
     def from_attributes(vals):
-        if len(vals) == 14:
+        nvals = len(vals)
+        uncertainty = 'None'
+        if nvals == 14:
             nbasicvals = 7
+            i = 11
+        elif nvals == 15:
+            nbasicvals = 7
+            i = 11
+            uncertainty = vals[i+2]
+        elif nvals == 12:
+            nbasicvals = 4
+            i = 8
+            uncertainty = vals[i+3]
         else:
             nbasicvals = 4
+            i = 8
+
         nslc_ids, tmin, tmax, kind = Marker.parse_attributes(
             vals[1:1+nbasicvals])
-
-        i = 8
-        if len(vals) == 14:
-            i = 11
 
         event_hash = str_to_str_or_none(vals[i-3])
         event_sdate = str_to_str_or_none(vals[i-2])
@@ -820,12 +861,14 @@ class PhaseMarker(Marker):
         else:
             event_time = None
 
-        phasename, polarity = [str_to_str_or_none(x) for x in vals[i:i+2]]
+        phasename = str_to_str_or_none(vals[i])
         automatic = str_to_bool(vals[i+2])
+        polarity = str_to_int_or_none(vals[i+1])
+        uncertainty = str_to_float_or_none(uncertainty)
         marker = PhaseMarker(nslc_ids, tmin, tmax, kind, event=None,
                              event_hash=event_hash, event_time=event_time,
                              phasename=phasename, polarity=polarity,
-                             automatic=automatic)
+                             automatic=automatic, uncertainty=uncertainty)
         return marker
 
 

--- a/src/gui/marker.py
+++ b/src/gui/marker.py
@@ -652,6 +652,7 @@ class EventMarker(Marker):
 
 
 class PhaseMarker(Marker):
+    polarity_symbols = {1: u'\u2191', -1:u'\u2193', None: u''}
     '''
     A PhaseMarker is a GUI-element representing a seismological phase arrival
 
@@ -708,7 +709,7 @@ class PhaseMarker(Marker):
         if self._phasename is not None:
             t.append(self._phasename)
         if self._polarity is not None:
-            t.append(self._polarity)
+            t.append(self.polarity_symbols.get(self._polarity, ''))
 
         if self._automatic:
             t.append('@')
@@ -746,6 +747,14 @@ class PhaseMarker(Marker):
 
     def set_phasename(self, phasename):
         self._phasename = phasename
+
+    def set_polarity(self, polarity):
+        if polarity not in [1, -1, 0, None]:
+            raise ValueError('polarity has to be 1, -1, 0 or None')
+        self._polarity = polarity
+
+    def get_polarity(self):
+        return self._polarity
 
     def convert_to_marker(self):
         del self._event

--- a/src/gui/marker.py
+++ b/src/gui/marker.py
@@ -182,7 +182,7 @@ class Marker(object):
 
         return markers
 
-    def __init__(self, nslc_ids, tmin, tmax, kind=0):
+    def __init__(self, nslc_ids, tmin, tmax, kind=0, uncertainty=0.):
         self.set(nslc_ids, tmin, tmax)
         c = plot.color
 
@@ -200,6 +200,7 @@ class Marker(object):
         self.alerted = False
         self.selected = False
         self.kind = kind
+        self.uncertainty = uncertainty
 
     def set(self, nslc_ids, tmin, tmax):
         '''Set ``nslc_ids``, start time and end time of :py:class:`Marker`
@@ -393,6 +394,8 @@ class Marker(object):
 
             if draw_line or self.selected or self.alerted:
                 p.setPen(linepen)
+                drawline(self.tmin - self.uncertainty)
+                drawline(self.tmax + self.uncertainty)
                 drawline(self.tmin)
                 drawline(self.tmax)
 

--- a/src/gui/pile_viewer.py
+++ b/src/gui/pile_viewer.py
@@ -2281,12 +2281,13 @@ def MakePileViewerMainClass(base):
                     markers = [self.floating_marker]
                 else:
                     markers = [
-                        x for x in self.selected_markers() if \
-                            isinstance(x, PhaseMarker)]
+                        x for x in self.selected_markers() if
+                        isinstance(x, PhaseMarker)]
+
                 self.update_marker_uncertainties(markers, wheel_delta/10.)
 
             else:
-                self.wheel_pos += wheel_delta 
+                self.wheel_pos += wheel_delta
 
                 n = self.wheel_pos // 120
                 self.wheel_pos = self.wheel_pos % 120
@@ -2295,7 +2296,8 @@ def MakePileViewerMainClass(base):
 
                 amount = max(
                     1.,
-                    abs(self.shown_tracks_range[0]-self.shown_tracks_range[1])/5.)
+                    abs(self.shown_tracks_range[0] -
+                        self.shown_tracks_range[1]) / 5.)
                 wdelta = amount * n
 
                 trmin, trmax = self.track_to_screen.get_in_range()
@@ -3528,8 +3530,6 @@ def MakePileViewerMainClass(base):
                 tmin, tmax = (
                     max(working_system_time_range[0], tmin),
                     min(working_system_time_range[1], tmax))
-
-                tcenter = tmin + (tmax - tmax) / 2.
 
                 p1 = self.mapToGlobal(qc.QPoint(x0, 0))
 

--- a/src/gui/pile_viewer.py
+++ b/src/gui/pile_viewer.py
@@ -1975,6 +1975,18 @@ def MakePileViewerMainClass(base):
                 self.interrupt_following()
                 self.set_time_range(self.tmin+dt, self.tmax+dt)
 
+            elif key_event.key() == qc.Qt.Key_Up:
+                for m in self.selected_markers():
+                    if isinstance(m, PhaseMarker):
+                        p = 1 if m.get_polarity() != 1 else None
+                        m.set_polarity(p)
+
+            elif key_event.key() == qc.Qt.Key_Down:
+                for m in self.selected_markers():
+                    if isinstance(m, PhaseMarker):
+                        p = -1 if m.get_polarity() != -1 else None
+                        m.set_polarity(p)
+
             elif keytext == 'b':
                 dt = self.tmax - self.tmin
                 self.interrupt_following()

--- a/test/test_marker.py
+++ b/test/test_marker.py
@@ -22,15 +22,21 @@ class MarkerTestCase(unittest.TestCase):
         pmarker = marker.PhaseMarker(nslc_ids=nslc_ids,  tmin=1., tmax=10.)
         pmarker.set_event(event)
 
+        pmarker_1 = marker.PhaseMarker(
+            nslc_ids=nslc_ids,  tmin=1., tmax=10., polarity=-1)
+        pmarker_2 = marker.PhaseMarker(
+            nslc_ids=nslc_ids,  tmin=1., tmax=10., uncertainty=2.)
+        pmarker_3 = marker.PhaseMarker(
+            nslc_ids=nslc_ids,  tmin=1., tmax=10., polarity=-1, uncertainty=-2.)
+
         emarker.set_alerted(True)
 
-        markers = [_marker, emarker, pmarker]
+        markers = [_marker, emarker, pmarker, pmarker_1, pmarker_2, pmarker_3]
         fn = tempfile.mkstemp()[1]
 
         marker.save_markers(markers, fn)
-
         in_markers = marker.load_markers(fn)
-        in__marker, in_emarker, in_pmarker = in_markers
+        in__marker, in_emarker, in_pmarker, pmarker_1, pmarker_2, pmarker_3 = in_markers
         for i, m in enumerate(in_markers):
             if not isinstance(m, marker.EventMarker):
                 assert (m.tmax - m.tmin) == 9.

--- a/test/test_marker.py
+++ b/test/test_marker.py
@@ -27,7 +27,8 @@ class MarkerTestCase(unittest.TestCase):
         pmarker_2 = marker.PhaseMarker(
             nslc_ids=nslc_ids,  tmin=1., tmax=10., uncertainty=2.)
         pmarker_3 = marker.PhaseMarker(
-            nslc_ids=nslc_ids,  tmin=1., tmax=10., polarity=-1, uncertainty=-2.)
+            nslc_ids=nslc_ids,  tmin=1., tmax=10., polarity=-1,
+            uncertainty=-2.)
 
         emarker.set_alerted(True)
 
@@ -36,7 +37,8 @@ class MarkerTestCase(unittest.TestCase):
 
         marker.save_markers(markers, fn)
         in_markers = marker.load_markers(fn)
-        in__marker, in_emarker, in_pmarker, pmarker_1, pmarker_2, pmarker_3 = in_markers
+        in__marker, in_emarker, in_pmarker, pmarker_1, pmarker_2, pmarker_3 = \
+            in_markers
         for i, m in enumerate(in_markers):
             if not isinstance(m, marker.EventMarker):
                 assert (m.tmax - m.tmin) == 9.


### PR DESCRIPTION
- Press shift and scroll to set uncertainty of PhaseMarkers. Testing read and write of old and new (with/without uncertainty) formatted marker files.
- Press arrows up/down to set polarity of PhaseMarkers

![example](https://user-images.githubusercontent.com/1038455/32664531-d0bbaf7e-c631-11e7-9c2a-79f7c19563c9.png)
