### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 Full installation instructions are available at 
-http://pyrocko.org/docs/current/install/.
+https://pyrocko.org/docs/current/install/.
 
 ### Installation from source
 
@@ -41,7 +41,7 @@ sudo pip install .
 
 ## Documentation
 
-Documentation and usage examples are available online at http://pyrocko.org/docs/current
+Documentation and usage examples are available online at https://pyrocko.org/docs/current
 
 ## Community Support
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Community support at [https://hive.pyrocko.org](https://hive.pyrocko.org/signup_
 ## Citation
 Recommended citation for Pyrocko
 
-> Heimann, Sebastian; Kriegerowski, Marius; Isken, Marius; Cesca, Simone; Daout, Simon; Grigoli, Francesco; Juretzek, Carina; Megies, Tobias; Nooshiri, Nima; Steinberg, Andreas; Sudhaus, Henriette; Vasyura-Bathke, Hannes; Willey, Timothy; Dahm, Torsten (2017): Pyrocko - An open-source seismology toolbox and library. V. 0.3. GFZ Data Services. http://doi.org/10.5880/GFZ.2.1.2017.001
+> Heimann, Sebastian; Kriegerowski, Marius; Isken, Marius; Cesca, Simone; Daout, Simon; Grigoli, Francesco; Juretzek, Carina; Megies, Tobias; Nooshiri, Nima; Steinberg, Andreas; Sudhaus, Henriette; Vasyura-Bathke, Hannes; Willey, Timothy; Dahm, Torsten (2017): Pyrocko - An open-source seismology toolbox and library. V. 0.3. GFZ Data Services. https://doi.org/10.5880/GFZ.2.1.2017.001
 
-[![DOI](https://img.shields.io/badge/DOI-10.5880%2FGFZ.2.1.2017.001-blue.svg)](http://doi.org/10.5880/GFZ.2.1.2017.001)
+[![DOI](https://img.shields.io/badge/DOI-10.5880%2FGFZ.2.1.2017.001-blue.svg)](https://doi.org/10.5880/GFZ.2.1.2017.001)
 
 ## License 
 GNU General Public License, Version 3, 29 June 2007

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -54,4 +54,4 @@ Indices and tables
 More manuals from the ecosystem:
 ---------------------------------
 
-* `Kite - Static displacement and InSAR post-processing <http://pyrocko.org/docs/kite>`_
+* `Kite - Static displacement and InSAR post-processing <https://pyrocko.org/docs/kite>`_

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,3 @@
 # A Collection of `pyrocko` Examples
 
-See descriptive filenames and Pyrocko docs (http://pyrocko.org/docs) for details.
+See descriptive filenames and Pyrocko docs (https://pyrocko.org/docs) for details.

--- a/maintenance/deploy-docs.sh
+++ b/maintenance/deploy-docs.sh
@@ -12,7 +12,7 @@ rm -rf build/$VERSION
 make clean; make html $1
 cp -r build/html build/$VERSION
 
-read -r -p "Are your sure to update live docs at http://pyrocko.org/docs/$VERSION [y/N]?" resp
+read -r -p "Are your sure to update live docs at https://pyrocko.org/docs/$VERSION [y/N]?" resp
 case $resp in
     [yY][eE][sS]|[yY] )
         rsync -av build/$VERSION pyrocko@hive:/var/www/pyrocko.org/docs;

--- a/src/fomosto/poel.py
+++ b/src/fomosto/poel.py
@@ -389,7 +389,7 @@ class PoelRunner(object):
 Available fomosto backends and download links to the modelling codes are listed
 on
 
-      http://pyrocko.org/current/apps/fomosto/backends.html
+      https://pyrocko.org/current/apps/fomosto/backends.html
 
 ''' % program)
 

--- a/src/fomosto/psgrn_pscmp.py
+++ b/src/fomosto/psgrn_pscmp.py
@@ -378,7 +378,7 @@ class PsGrnRunner(object):
 Available fomosto backends and download links to the modelling codes are listed
 on
 
-      http://pyrocko.org/current/apps/fomosto/backends.html
+      https://pyrocko.org/current/apps/fomosto/backends.html
 
 ''' % program)
 
@@ -1191,7 +1191,7 @@ class PsCmpRunner(object):
 Available fomosto backends and download links to the modelling codes are listed
 on
 
-      http://pyrocko.org/current/apps/fomosto/backends.html
+      https://pyrocko.org/current/apps/fomosto/backends.html
 
 ''' % program)
 

--- a/src/fomosto/qseis.py
+++ b/src/fomosto/qseis.py
@@ -638,7 +638,7 @@ class QSeisRunner(object):
 Available fomosto backends and download links to the modelling codes are listed
 on
 
-      http://pyrocko.org/current/apps/fomosto/backends.html
+      https://pyrocko.org/current/apps/fomosto/backends.html
 
 ''' % program)
 

--- a/src/fomosto/qssp.py
+++ b/src/fomosto/qssp.py
@@ -483,7 +483,7 @@ class QSSPRunner(object):
 Available fomosto backends and download links to the modelling codes are listed
 on
 
-      http://pyrocko.org/current/apps/fomosto/backends.html
+      https://pyrocko.org/current/apps/fomosto/backends.html
 
 ''' % program)
 


### PR DESCRIPTION
Hello!

The DOI foundation [recommends SSL/TLS to link to their resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) ;-) Also, since your homepages supports that as well, I updated those URLs also.

Cheers :-)