### PR TITLE
Offer citation metadata also as BibTeX

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,11 @@
+@software{pyrocko,
+  title = {Pyrocko: {{A}} Versatile Seismology Toolkit for {{Python}}.},
+  rights = {GPLv3},
+  url = {http://pyrocko.org},
+  shorttitle = {Pyrocko},
+  version = {2018.1.29},
+  urldate = {2018-02-23},
+  keywords = {Scientific/Engineering,Scientific/Engineering - Information Analysis,Scientific/Engineering - Physics,Scientific/Engineering - Visualization,Software Development - Libraries - Application Frameworks},
+  author = {The Pyrocko Developers},
+  doi = {10.5880/GFZ.2.1.2017.001}
+}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Documentation and usage examples are available online at http://pyrocko.org/docs
 Community support at [https://hive.pyrocko.org](https://hive.pyrocko.org/signup_user_complete/?id=9edryhxeptdbmxrecbwy3zg49y).
 
 ## Citation
-Recommended citation for Pyrocko
+The recommended citation for Pyrocko is: (You can find the BibTeX snippet in the
+[`CITATION` file](CITATION)):
 
 > Heimann, Sebastian; Kriegerowski, Marius; Isken, Marius; Cesca, Simone; Daout, Simon; Grigoli, Francesco; Juretzek, Carina; Megies, Tobias; Nooshiri, Nima; Steinberg, Andreas; Sudhaus, Henriette; Vasyura-Bathke, Hannes; Willey, Timothy; Dahm, Torsten (2017): Pyrocko - An open-source seismology toolbox and library. V. 0.3. GFZ Data Services. http://doi.org/10.5880/GFZ.2.1.2017.001
 


### PR DESCRIPTION
Hello! This [`CITATION` file convention is suggested by the Software Sustainability Institute](https://www.software.ac.uk/blog/2013-09-02-encouraging-citation-software-introducing-citation-files). Just a quick way for people to import the citation data into their reference management workflow. Cheers :-)