### PR TITLE
BUGFIX fomosto tttextract --output

### DIFF
--- a/src/apps/fomosto.py
+++ b/src/apps/fomosto.py
@@ -920,7 +920,7 @@ def command_tttextract(args):
 
                 fn = options.output_fn % d
                 util.ensuredirs(fn)
-                with open(fn, 'w') as f:
+                with open(fn, 'a') as f:
                     f.write(' '.join(s))
                     f.write('\n')
             else:


### PR DESCRIPTION
If an outfile was specified always only the last extracted travel time entry was written, because previous ones were overwritten ...