### PR TITLE
Phase marker update

### DIFF
--- a/src/gui/marker.py
+++ b/src/gui/marker.py
@@ -704,7 +704,15 @@ class PhaseMarker(Marker):
         t = []
         if self._phasename is not None:
             t.append(self._phasename)
-        if self._polarity is not None:
+        if self._polarity is None:
+            pass
+        elif self._polarity == 'positive':
+            t.append('+')
+        elif self._polarity == 'negative':
+            t.append('-')
+        elif self._polarity == 'undecidable':
+            t.append('0')
+        else:
             t.append(self._polarity)
 
         if self._automatic:

--- a/src/gui/marker.py
+++ b/src/gui/marker.py
@@ -746,6 +746,12 @@ class PhaseMarker(Marker):
     def set_phasename(self, phasename):
         self._phasename = phasename
 
+    def get_polarity(self):
+        return self._polarity
+
+    def set_polarity(self, polarity):
+        self._polarity = polarity
+
     def convert_to_marker(self):
         del self._event
         del self._event_hash

--- a/src/gui/snufflings/map/map_googlemaps.html
+++ b/src/gui/snufflings/map/map_googlemaps.html
@@ -183,7 +183,7 @@
               marker[i] = new google.maps.Marker({
                 position: epicenterlocation,
                 icon: { path: google.maps.SymbolPath.CIRCLE,
-                  scale: 3,
+                  scale: 4,
                   strokeColor: 'red'},
                   title: name + 
                   "\n" + 'origin time: '+time+


### PR DESCRIPTION
1.) Added functions `get_polarity` and `set_polarity` to the PhaseMarker class, as they were missing. Otherwise it wouldn't be possible to set the polarity of a phase-pick through snuffler.

2.) Adjusted the function `get_label` in the PhaseMarker class. In this version the label of a phase-pick will show '+' for positive, '-' for negative and '0' for undecidable polarities next to the phase name. This makes it better readable and less blown up.