### PR TITLE
replacing explicit code with link

### DIFF
--- a/doc/source/apps/cake/manual.rst
+++ b/doc/source/apps/cake/manual.rst
@@ -409,30 +409,8 @@ Calculate P-phase arrivals
 
 The following Python script calculates arrival times for the P-phase emitted by an event in a depth of 300km.
 
-::
+.. literalinclude :: /../../examples/cake_arrivals.py
+    :language: python
 
-    '''
-    Calculate P-phase arrivals.
-    '''
 
-    from pyrocko import cake
-    import numpy as num
-    km = 1000.
-
-    # Load builtin 'prem-no-ocean' model ('.m': medium resolution variant)
-    model = cake.load_model('prem-no-ocean.m')
-
-    # Source depth [m].
-    source_depth = 300. * km
-
-    # Distances as a numpy array [deg].
-    distances = num.linspace(1500,3000,16)*km * cake.m2d
-
-    # Define the phase to use.
-    Phase = cake.PhaseDef('P')
-
-    # calculate distances and arrivals and print them:
-    print 'distance [km]      time [s]'
-    for arrival in model.arrivals(distances, phases=Phase, zstart=source_depth):
-        print '%13g %13g' % (arrival.x*cake.d2m/km, arrival.t)
 


### PR DESCRIPTION
Some parts of the rst-files still contain explicit codes
which can be replaced by linking them to the existing .py-file in the pyrocko archive (so done here for the cake-manual)