### PR TITLE
Cake, saving option

### DIFF
--- a/doc/source/apps/cake/manual.rst
+++ b/doc/source/apps/cake/manual.rst
@@ -409,30 +409,8 @@ Calculate P-phase arrivals
 
 The following Python script calculates arrival times for the P-phase emitted by an event in a depth of 300km.
 
-::
+.. literalinclude :: /../../examples/cake_arrivals.py
+    :language: python
 
-    '''
-    Calculate P-phase arrivals.
-    '''
 
-    from pyrocko import cake
-    import numpy as num
-    km = 1000.
-
-    # Load builtin 'prem-no-ocean' model ('.m': medium resolution variant)
-    model = cake.load_model('prem-no-ocean.m')
-
-    # Source depth [m].
-    source_depth = 300. * km
-
-    # Distances as a numpy array [deg].
-    distances = num.linspace(1500,3000,16)*km * cake.m2d
-
-    # Define the phase to use.
-    Phase = cake.PhaseDef('P')
-
-    # calculate distances and arrivals and print them:
-    print 'distance [km]      time [s]'
-    for arrival in model.arrivals(distances, phases=Phase, zstart=source_depth):
-        print '%13g %13g' % (arrival.x*cake.d2m/km, arrival.t)
 

--- a/src/apps/cake.py
+++ b/src/apps/cake.py
@@ -621,10 +621,7 @@ def plot_init (size,save,show):
     labelpos(axes, 2., 1.5)
 
     axes.plot([0, 1], [0, 9])
-    if show or not(save):
-        showplt=True
-    else:
-        showplt=False # there might be smarter expressions
+    showplt = bool(show or not save)
 
     return fig, axes, showplt
 

--- a/src/apps/cake.py
+++ b/src/apps/cake.py
@@ -11,6 +11,9 @@ import numpy as num
 from pyrocko import cake, util, orthodrome
 from pyrocko.plot import cake_plot as plot
 from optparse import OptionParser, OptionGroup
+import matplotlib.pyplot as plt
+from pyrocko.plot import mpl_init, mpl_papersize, mpl_margins, \
+    mpl_graph_color, mpl_color
 
 r2d = cake.r2d
 
@@ -257,8 +260,8 @@ as in --phases.''')
 
         parser.add_option_group(group)
 
-    if any(x in want for x in ('output_format',)):
-        group = OptionGroup(parser, 'Output')
+    if any(x in want for x in ('output_format','save','size','show')):
+        group = OptionGroup(parser, 'Output','Output specifications')
         if 'output_format' in want:
             group.add_option(
                 '--output-format', dest='output_format', metavar='FORMAT',
@@ -266,6 +269,22 @@ as in --phases.''')
                 choices=('textual', 'nd'),
                 help='Set model output format (available: textual, nd, '
                      'default: textual)')
+        if 'save' in want:
+            group.add_option(
+                '-s','--save', dest='save', metavar='PATH',
+                help='saves plot to .png (default) or other py-supported endings without showing, use --show or -u for showing',
+                default='')
+        if 'size' in want:
+            group.add_option(
+                '--size', dest='size', type='string',
+                default='a4',
+                help='gives size of returned plot, use \'a5\' or \'a4\'')
+        if 'show' in want:
+            group.add_option(
+                '-u', '--show', dest='show', action='store_true',
+                help='shows plot when saving (-u for unhide)')
+
+
 
         parser.add_option_group(group)
 
@@ -289,6 +308,15 @@ as in --phases.''')
 
     if 'output_format' in want:
         d['output_format'] = options.output_format
+
+    if 'save' in want:
+        d['save'] = options.save
+
+    if 'size' in want:
+        d['size']= options.size
+
+    if 'show' in want:
+        d['show']= options.show
 
     if 'aspect' in want:
         d['aspect'] = options.aspect
@@ -583,6 +611,40 @@ def print_arrivals(
             space)) + tuple(
                 x.ljust(17) for x in (ray.path.phase.definition(), su))))
 
+def plot_init (size,save,show):
+    fontsize = 9
+    mpl_init()
+    fig = plt.figure(figsize=mpl_papersize(size, 'landscape'))
+
+    labelpos = mpl_margins(fig, w=7., h=5., units=fontsize)
+    axes = fig.add_subplot(1, 1, 1)
+    labelpos(axes, 2., 1.5)
+
+    axes.plot([0, 1], [0, 9])
+    if show or not(save):
+        showplt=True
+    else:
+        showplt=False # there might be smarter expressions
+
+    return fig, axes, showplt
+
+def plot_end (save,fig,show=True):
+    if save:
+        try:
+            fig.savefig(save)
+            if show:
+                plt.show()
+            print('figure was saved')
+        except FileNotFoundError:
+            print('Path not defined, use an excisting path')
+        except ValueError:
+        	print('Format not supported, use one of these: eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff.')
+
+            
+
+
+
+
 
 def main(args=None):
 
@@ -677,15 +739,15 @@ To get further help and a list of available options for any subcommand run:
     elif command in ('plot-xt', 'plot-xp', 'plot-rays', 'plot'):
         if command in ('plot-xt', 'plot'):
             c = optparse(
-                ('model', 'phases'),
+                ('model', 'phases',),
                 ('zstart', 'zstop', 'distances', 'as_degrees', 'vred',
-                 'phase_colors'),
+                 'phase_colors', 'save', 'size','show'),
                 usage=subusage, descr=descr)
         else:
             c = optparse(
                 ('model', 'phases'),
                 ('zstart', 'zstop', 'distances', 'as_degrees', 'aspect',
-                 'shade_model', 'phase_colors'),
+                 'shade_model', 'phase_colors', 'save', 'size','show'),
                 usage=subusage, descr=descr)
 
         mod = c.model
@@ -697,34 +759,45 @@ To get further help and a list of available options for any subcommand run:
         else:
             arrivals = None
 
-        if command == 'plot-xp':
-            plot.my_xp_plot(
-                paths, c.zstart, c.zstop, c.distances, c.as_degrees,
-                phase_colors=c.phase_colors)
-        elif command == 'plot-xt':
+        
+        fig, axes, showplt = plot_init(c.size,c.save,c.show)
+
+
+        if command == 'plot-xp':            
+                plot.my_xp_plot(
+                    paths, c.zstart, c.zstop, c.distances, c.as_degrees,show=showplt,
+                    phase_colors=c.phase_colors)
+
+        elif command == 'plot-xt':              
             plot.my_xt_plot(
-                paths, c.zstart, c.zstop, c.distances, c.as_degrees,
-                vred=c.vred, phase_colors=c.phase_colors)
+                paths, c.zstart, c.zstop, c.distances, c.as_degrees, 
+                vred=c.vred, axes=axes, show=showplt, phase_colors=c.phase_colors)
+
         elif command == 'plot-rays':
             if c.as_degrees:
                 plot.my_rays_plot_gcs(
-                    mod, paths, arrivals, c.zstart, c.zstop, c.distances,
+                    mod, paths, arrivals, c.zstart, c.zstop, c.distances, show=showplt,
                     phase_colors=c.phase_colors)
+
             else:
                 plot.my_rays_plot(
-                    mod, paths, arrivals, c.zstart, c.zstop, c.distances,
+                    mod, paths, arrivals, c.zstart, c.zstop, c.distances, show=showplt,
                     aspect=c.aspect, shade_model=c.shade_model,
                     phase_colors=c.phase_colors)
 
         elif command == 'plot':
             plot.my_combi_plot(
-                mod, paths, arrivals, c.zstart, c.zstop, c.distances,
-                c.as_degrees, vred=c.vred, phase_colors=c.phase_colors)
+                mod, paths, arrivals, c.zstart, c.zstop, c.distances, 
+                c.as_degrees, show=showplt, vred=c.vred, phase_colors=c.phase_colors)
+
+        plot_end(save=c.save,fig=fig,show=c.show) 
 
     elif command in ('plot-model',):
-        c = optparse(('model',), (), usage=subusage, descr=descr)
+        c = optparse(('model',), ('save', 'size','show'), usage=subusage, descr=descr, )
         mod = c.model
-        plot.my_model_plot(mod)
+        fig, axes, showplt = plot_init(c.size,c.save,c.show)
+        plot.my_model_plot(mod,show=showplt) 
+        plot_end(save=c.save,fig=fig,show=c.show) 
 
     elif command in ('simplify-model',):
         c = optparse(('model',), ('accuracy',), usage=subusage, descr=descr)
@@ -754,7 +827,7 @@ To get further help and a list of available options for any subcommand run:
             (),
             ('model', 'accuracy', 'slowness', 'interface', 'phases',
              'distances', 'zstart', 'zstop', 'distances', 'as_degrees',
-             'material', 'vred'),
+             'material', 'vred','save'),
             usage='cake help-options', descr='list all available options')
 
     elif command in ('--help', '-h', 'help'):
@@ -762,7 +835,6 @@ To get further help and a list of available options for any subcommand run:
 
     else:
         sys.exit('cake: no such subcommand: %s' % command)
-
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/src/plot/cake_plot.py
+++ b/src/plot/cake_plot.py
@@ -10,6 +10,8 @@ import numpy as num
 from pyrocko import cake
 from . import mpl_labelspace as labelspace, mpl_init,\
     mpl_color as str_to_mpl_color, InvalidColorDef
+from pyrocko.plot import mpl_init, mpl_papersize, mpl_margins, \
+    mpl_graph_color, mpl_color
 
 str_to_mpl_color
 InvalidColorDef
@@ -543,12 +545,42 @@ def plot_surface_efficiency(mat):
     plt.show()
 
 
+def my_xp_plot(
+        paths, zstart, zstop,
+        distances=None,
+        as_degrees=False,
+        axes=None,
+        show=True,
+        phase_colors={}):
+
+    if axes is None:
+        from matplotlib import pyplot as plt
+        mpl_init()
+        axes = plt.gca()
+    else:
+        plt = None
+
+    labelspace(axes)
+    xmin, xmax = plot_xp(
+        paths, zstart, zstop, axes=axes, phase_colors=phase_colors)
+
+    if distances is not None:
+        xmin, xmax = distances.min(), distances.max()
+
+    axes.set_xlim(xmin, xmax)
+    labels_xp(as_degrees=as_degrees, axes=axes)
+
+    if plt:
+        if show is True:
+            plt.show()
+
 def my_xt_plot(
         paths, zstart, zstop,
         distances=None,
         as_degrees=False,
         vred=None,
         axes=None,
+        show=True,
         phase_colors={}):
 
     if axes is None:
@@ -575,40 +607,14 @@ def my_xt_plot(
     axes.set_ylim(ymin, ymax)
     labels_xt(as_degrees=as_degrees, vred=vred, axes=axes)
     if plt:
-        plt.show()
-
-
-def my_xp_plot(
-        paths, zstart, zstop,
-        distances=None,
-        as_degrees=False,
-        axes=None,
-        phase_colors={}):
-
-    if axes is None:
-        from matplotlib import pyplot as plt
-        mpl_init()
-        axes = plt.gca()
-    else:
-        plt = None
-
-    labelspace(axes)
-    xmin, xmax = plot_xp(
-        paths, zstart, zstop, axes=axes, phase_colors=phase_colors)
-
-    if distances is not None:
-        xmin, xmax = distances.min(), distances.max()
-
-    axes.set_xlim(xmin, xmax)
-    labels_xp(as_degrees=as_degrees, axes=axes)
-
-    if plt:
-        plt.show()
+        if show is True:
+            plt.show()
 
 
 def my_rays_plot_gcs(
         mod, paths, rays, zstart, zstop,
         distances=None,
+        show=True,
         phase_colors={}):
 
     from matplotlib import pyplot as plt
@@ -625,7 +631,8 @@ def my_rays_plot_gcs(
     axes.get_yaxis().set_visible(False)
 
     if plt:
-        plt.show()
+        if show is True:
+            plt.show()
 
 
 def my_rays_plot(
@@ -633,6 +640,7 @@ def my_rays_plot(
         distances=None,
         as_degrees=False,
         axes=None,
+        show=True,
         aspect=None,
         shade_model=True,
         phase_colors={}):
@@ -666,13 +674,14 @@ def my_rays_plot(
     axes.set_ylim(ymax+my, ymin-my)
 
     if plt:
-        plt.show()
-
+        if show is True:
+            plt.show()
 
 def my_combi_plot(
         mod, paths, rays, zstart, zstop,
         distances=None,
         as_degrees=False,
+        show=True,
         vred=None,
         phase_colors={}):
 
@@ -709,10 +718,12 @@ def my_combi_plot(
     my = (ymax-ymin)*0.05
     ax2.set_xlim(xmin-mx, xmax+mx)
     ax2.set_ylim(ymax+my, ymin-my)
-    plt.show()
+    
+    if show is True:
+        plt.show()
 
 
-def my_model_plot(mod, axes=None):
+def my_model_plot(mod, axes=None, show=True):
 
     if axes is None:
         from matplotlib import pyplot as plt
@@ -737,4 +748,6 @@ def my_model_plot(mod, axes=None):
     axes.set_ylim(ymax+my, ymin-my)
     axes.set_xlim(xmin, xmax+mx)
     if plt:
-        plt.show()
+        if show is True:
+            plt.show()
+


### PR DESCRIPTION
As it was nice to have a saving option for cake figures, I added some features including a silent save function with the option to --show it anyway and a --size option which refers to the size chart in __init__.py (in the plot folder)
Latter option might be optimized later, but for initial use the given sizes are sufficient.

Furthermore, the rst-code for the Cake-documentation was replaced by the link to the respective original file (thus removing troubles when updating it).