### PR TITLE
BUG: Fix explosion source

### DIFF
--- a/src/gf/seismosizer.py
+++ b/src/gf/seismosizer.py
@@ -1251,7 +1251,7 @@ class ExplosionSource(SourceWithDerivedMagnitude):
             return float(mt.moment_to_magnitude(moment))
 
         else:
-            return float(mt.moment_to_magnitude(1.0))
+            return float(mt.moment_to_magnitude(1.0)) # * math.sqrt(3. / 2.))
 
     def get_volume_change(self, store=None, target=None):
         self.check_conflicts()
@@ -1259,9 +1259,14 @@ class ExplosionSource(SourceWithDerivedMagnitude):
         if self.volume_change is not None:
             return self.volume_change
 
+        #    math.sqrt(num.sum(m6[0:3]**2) + 2.0 * num.sum(m6[3:6]**2))
+        #    / math.sqrt(2.))
+
         elif self.magnitude is not None:
             moment = float(mt.magnitude_to_moment(self.magnitude))
-            return moment / self.get_moment_to_volume_change_ratio(
+            mt_moment = math.sqrt(2. / 3) * moment
+            print('moment', moment, 'mt_moment', mt_moment)
+            return mt_moment / self.get_moment_to_volume_change_ratio(
                 store, target)
 
         else:
@@ -1294,14 +1299,15 @@ class ExplosionSource(SourceWithDerivedMagnitude):
         times, amplitudes = self.effective_stf_pre().discretize_t(
             store.config.deltat, 0.0)
 
-        amplitudes *= self.get_moment(store, target)
+        amplitudes *= self.get_moment(store, target) # * math.sqrt(3. / 2.)
+        print(amplitudes)
 
         return meta.DiscretizedExplosionSource(
             m0s=amplitudes,
             **self._dparams_base_repeated(times))
 
     def pyrocko_moment_tensor(self, store=None, target=None):
-        a = self.get_moment(store, target) * math.sqrt(2./3.)
+        a = self.get_moment(store, target) * math.sqrt(2. / 3.)
         return mt.MomentTensor(m=mt.symmat6(a, a, a, 0., 0., 0.))
 
 
@@ -1594,9 +1600,9 @@ class MTSource(Source):
 
     def get_magnitude(self, store=None, target=None):
         m6 = self.m6
-        return mt.moment_to_magnitude(
-            math.sqrt(num.sum(m6[0:3]**2) + 2.0 * num.sum(m6[3:6]**2))
-            / math.sqrt(2.))
+        sm = math.sqrt(num.sum(m6[0:3]**2) + 2.0 * num.sum(m6[3:6]**2)) / math.sqrt(2.)
+        print('sm', sm)
+        return mt.moment_to_magnitude(sm)
 
     def pyrocko_moment_tensor(self, store=None, target=None):
         return mt.MomentTensor(m=mt.symmat6(*self.m6_astuple))

--- a/src/gf/seismosizer.py
+++ b/src/gf/seismosizer.py
@@ -1251,7 +1251,7 @@ class ExplosionSource(SourceWithDerivedMagnitude):
             return float(mt.moment_to_magnitude(moment))
 
         else:
-            return float(mt.moment_to_magnitude(1.0)) # * math.sqrt(3. / 2.))
+            return float(mt.moment_to_magnitude(1.0))
 
     def get_volume_change(self, store=None, target=None):
         self.check_conflicts()
@@ -1259,14 +1259,9 @@ class ExplosionSource(SourceWithDerivedMagnitude):
         if self.volume_change is not None:
             return self.volume_change
 
-        #    math.sqrt(num.sum(m6[0:3]**2) + 2.0 * num.sum(m6[3:6]**2))
-        #    / math.sqrt(2.))
-
         elif self.magnitude is not None:
             moment = float(mt.magnitude_to_moment(self.magnitude))
-            mt_moment = math.sqrt(2. / 3) * moment
-            print('moment', moment, 'mt_moment', mt_moment)
-            return mt_moment / self.get_moment_to_volume_change_ratio(
+            return moment / self.get_moment_to_volume_change_ratio(
                 store, target)
 
         else:
@@ -1299,7 +1294,7 @@ class ExplosionSource(SourceWithDerivedMagnitude):
         times, amplitudes = self.effective_stf_pre().discretize_t(
             store.config.deltat, 0.0)
 
-        amplitudes *= self.get_moment(store, target) # * math.sqrt(3. / 2.)
+        amplitudes *= self.get_moment(store, target)  * math.sqrt(2. / 3.)
         print(amplitudes)
 
         return meta.DiscretizedExplosionSource(
@@ -1600,9 +1595,9 @@ class MTSource(Source):
 
     def get_magnitude(self, store=None, target=None):
         m6 = self.m6
-        sm = math.sqrt(num.sum(m6[0:3]**2) + 2.0 * num.sum(m6[3:6]**2)) / math.sqrt(2.)
-        print('sm', sm)
-        return mt.moment_to_magnitude(sm)
+        return mt.moment_to_magnitude(
+            math.sqrt(num.sum(m6[0:3]**2) + 2.0 * num.sum(m6[3:6]**2)) /
+            math.sqrt(2.))
 
     def pyrocko_moment_tensor(self, store=None, target=None):
         return mt.MomentTensor(m=mt.symmat6(*self.m6_astuple))

--- a/src/gf/seismosizer.py
+++ b/src/gf/seismosizer.py
@@ -1294,8 +1294,7 @@ class ExplosionSource(SourceWithDerivedMagnitude):
         times, amplitudes = self.effective_stf_pre().discretize_t(
             store.config.deltat, 0.0)
 
-        amplitudes *= self.get_moment(store, target)  * math.sqrt(2. / 3.)
-        print(amplitudes)
+        amplitudes *= self.get_moment(store, target) * math.sqrt(2. / 3.)
 
         return meta.DiscretizedExplosionSource(
             m0s=amplitudes,

--- a/test/test_gf_sources.py
+++ b/test/test_gf_sources.py
@@ -342,7 +342,6 @@ class GFSourcesTestCase(unittest.TestCase):
         moment = ex.get_moment(store, target) * float(num.sqrt(2. / 3))
 
         mt = gf.MTSource(mnn=moment, mee=moment, mdd=moment)
-        d_mt = mt.discretize_basesource(store=store, target=target)
 
         self.assertAlmostEqual(
             ex.get_magnitude(store, target),

--- a/test/test_gf_sources.py
+++ b/test/test_gf_sources.py
@@ -307,15 +307,15 @@ class GFSourcesTestCase(unittest.TestCase):
             interpolation='nearest_neighbor')
 
         ex = gf.ExplosionSource(
-                magnitude=5.,
-                volume_change=4.,
-                depth=5*km)
+            magnitude=5.,
+            volume_change=4.,
+            depth=5 * km)
 
         with self.assertRaises(gf.DerivedMagnitudeError):
             ex.validate()
 
         ex = gf.ExplosionSource(
-                depth=5*km)
+            depth=5 * km)
 
         ex.validate()
 
@@ -324,8 +324,8 @@ class GFSourcesTestCase(unittest.TestCase):
         # magnitude input
         magnitude = 3.
         ex = gf.ExplosionSource(
-                magnitude=magnitude,
-                depth=5*km)
+            magnitude=magnitude,
+            depth=5 * km)
 
         store = self.dummy_store()
 
@@ -339,29 +339,40 @@ class GFSourcesTestCase(unittest.TestCase):
             ex.get_magnitude(store, target), magnitude)
 
         # validate with MT source
-        moment = ex.get_moment(store, target)
-        print(moment)
+        moment = ex.get_moment(store, target) * float(num.sqrt(2. / 3))
+
         mt = gf.MTSource(mnn=moment, mee=moment, mdd=moment)
-        print(mt)
+        d_mt = mt.discretize_basesource(store=store, target=target)
+
         self.assertAlmostEqual(
             ex.get_magnitude(store, target),
             mt.get_magnitude(store=store, target=target))
 
+        # discretized sources
+        d_ex = ex.discretize_basesource(store=store, target=target)
+        d_mt = mt.discretize_basesource(store=store, target=target)
+
+        d_ex_m6s = d_ex.get_source_terms('elastic10')
+        d_mt_m6s = d_mt.get_source_terms('elastic10')
+
+        numeq(d_ex_m6s, d_mt_m6s, 1e-20)
+
+        # interpolation method
         with self.assertRaises(TypeError):
             ex.get_volume_change(
                 store, gf.Target(interpolation='nearest_neighbour'))
 
         # volume change input
         ex = gf.ExplosionSource(
-                volume_change=volume_change,
-                depth=5*km)
+            volume_change=volume_change,
+            depth=5 * km)
 
         self.assertAlmostEqual(
             ex.get_magnitude(store, target), 3.0)
 
         ex = gf.ExplosionSource(
-                magnitude=3.0,
-                depth=-5.)
+            magnitude=3.0,
+            depth=-5.)
 
         with self.assertRaises(gf.DerivedMagnitudeError):
             ex.get_volume_change(store, target)

--- a/test/test_gf_sources.py
+++ b/test/test_gf_sources.py
@@ -302,6 +302,7 @@ class GFSourcesTestCase(unittest.TestCase):
         # plot_sources(sources)
 
     def test_explosion_source(self):
+
         target = gf.Target(
             interpolation='nearest_neighbor')
 
@@ -320,8 +321,10 @@ class GFSourcesTestCase(unittest.TestCase):
 
         self.assertEqual(ex.get_moment(), 1.0)
 
+        # magnitude input
+        magnitude = 3.
         ex = gf.ExplosionSource(
-                magnitude=3.0,
+                magnitude=magnitude,
                 depth=5*km)
 
         store = self.dummy_store()
@@ -332,10 +335,23 @@ class GFSourcesTestCase(unittest.TestCase):
         volume_change = ex.get_volume_change(
             store, target)
 
+        self.assertAlmostEqual(
+            ex.get_magnitude(store, target), magnitude)
+
+        # validate with MT source
+        moment = ex.get_moment(store, target)
+        print(moment)
+        mt = gf.MTSource(mnn=moment, mee=moment, mdd=moment)
+        print(mt)
+        self.assertAlmostEqual(
+            ex.get_magnitude(store, target),
+            mt.get_magnitude(store=store, target=target))
+
         with self.assertRaises(TypeError):
             ex.get_volume_change(
                 store, gf.Target(interpolation='nearest_neighbour'))
 
+        # volume change input
         ex = gf.ExplosionSource(
                 volume_change=volume_change,
                 depth=5*km)


### PR DESCRIPTION
The moment of the discretized explosion source was too high. 
Added tests to cover this.
