### PR TITLE
b-values in scenario generator

### DIFF
--- a/src/moment_tensor.py
+++ b/src/moment_tensor.py
@@ -1047,6 +1047,13 @@ def kagan_angle(mt1, mt2):
     return 2. * r2d * math.acos(num.max(num.abs(qk)))
 
 
+def rand_to_gutenberg_richter(rand, b_value, magnitude_min):
+    '''
+    Draw magnitude from Gutenberg Richter distribution.
+    '''
+    return magnitude_min + num.log10(1.-rand) / -b_value
+
+
 if __name__ == '__main__':
 
     import sys

--- a/src/scenario/sources/base.py
+++ b/src/scenario/sources/base.py
@@ -1,6 +1,6 @@
 import os.path as op
 
-from pyrocko import util
+from pyrocko import util, moment_tensor
 from pyrocko.guts import Timestamp, Float, Int, Bool
 
 from ..base import LocationGenerator
@@ -24,15 +24,15 @@ class SourceGenerator(LocationGenerator):
 
     magnitude_min = Float.T(default=4.0)
     magnitude_max = Float.T(default=0.0)
-    b_value = Float.T(optional=True,
-        help='Gutenberg Richter magnitude distribution.')
+    b_value = Float.T(
+        optional=True, help='Gutenberg Richter magnitude distribution.')
 
     def __init__(self, *args, **kwargs):
         super(SourceGenerator, self).__init__(*args, **kwargs)
         if self.b_value and self.magnitude_max:
             raise Exception('b_value and magnitude_max are mutually exclusive')
 
-    def draw_magnitude(self):
+    def draw_magnitude(self, rstate):
         if self.magnitude_max:
             return rstate.uniform(self.magnitude_min, self.magnitude_max)
         else:

--- a/src/scenario/sources/base.py
+++ b/src/scenario/sources/base.py
@@ -23,7 +23,21 @@ class SourceGenerator(LocationGenerator):
     time_max = Timestamp.T(default=util.str_to_time('2017-01-03 00:00:00'))
 
     magnitude_min = Float.T(default=4.0)
-    magnitude_max = Float.T(default=7.0)
+    magnitude_max = Float.T(default=0.0)
+    b_value = Float.T(optional=True,
+        help='Gutenberg Richter magnitude distribution.')
+
+    def __init__(self, *args, **kwargs):
+        super(SourceGenerator, self).__init__(*args, **kwargs)
+        if self.b_value and self.magnitude_max:
+            raise Exception('b_value and magnitude_max are mutually exclusive')
+
+    def draw_magnitude(self):
+        if self.magnitude_max:
+            return rstate.uniform(self.magnitude_min, self.magnitude_max)
+        else:
+            return moment_tensor.rand_to_gutenberg_richter(
+                rstate.rand(), self.b_value, magnitude_min=self.magnitude_min)
 
     def get_sources(self):
         sources = []

--- a/src/scenario/sources/dcsource.py
+++ b/src/scenario/sources/dcsource.py
@@ -25,7 +25,7 @@ class DCSourceGenerator(SourceGenerator):
         time = rstate.uniform(self.time_min, self.time_max)
         lat, lon = self.get_latlon(ievent)
         depth = rstate.uniform(self.depth_min, self.depth_max)
-        magnitude = rstate.uniform(self.magnitude_min, self.magnitude_max)
+        magnitude = self.draw_magnitude()
 
         if self.strike is None and self.dip is None and self.rake is None:
             mt = moment_tensor.MomentTensor.random_dc(x=rstate.uniform(size=3))

--- a/src/scenario/sources/dcsource.py
+++ b/src/scenario/sources/dcsource.py
@@ -25,7 +25,7 @@ class DCSourceGenerator(SourceGenerator):
         time = rstate.uniform(self.time_min, self.time_max)
         lat, lon = self.get_latlon(ievent)
         depth = rstate.uniform(self.depth_min, self.depth_max)
-        magnitude = self.draw_magnitude()
+        magnitude = self.draw_magnitude(rstate)
 
         if self.strike is None and self.dip is None and self.rake is None:
             mt = moment_tensor.MomentTensor.random_dc(x=rstate.uniform(size=3))

--- a/src/scenario/sources/rectangularsource.py
+++ b/src/scenario/sources/rectangularsource.py
@@ -34,7 +34,7 @@ class RectangularSourceGenerator(SourceGenerator):
         lat, lon = self.get_latlon(ievent)
         depth = rstate.uniform(self.depth_min, self.depth_max)
 
-        magnitude = self.draw_magnitude()
+        magnitude = self.draw_magnitude(rstate)
         moment = moment_tensor.magnitude_to_moment(magnitude)
 
         # After Mai and Beroza (2000)

--- a/src/scenario/sources/rectangularsource.py
+++ b/src/scenario/sources/rectangularsource.py
@@ -33,8 +33,8 @@ class RectangularSourceGenerator(SourceGenerator):
         time = rstate.uniform(self.time_min, self.time_max)
         lat, lon = self.get_latlon(ievent)
         depth = rstate.uniform(self.depth_min, self.depth_max)
-        magnitude = rstate.uniform(self.magnitude_min, self.magnitude_max)
 
+        magnitude = self.draw_magnitude()
         moment = moment_tensor.magnitude_to_moment(magnitude)
 
         # After Mai and Beroza (2000)


### PR DESCRIPTION
Allows to define a `b_value` which is mutually exclusive with `magnitude_max`. If the latter is given the standard behavior is used which means drawing a random magnitude from a uniform distribution. If a `b_value` is defined magnitudes as in the lower left panel are produced:
![image](https://user-images.githubusercontent.com/1038455/51803479-f33df800-2255-11e9-84f1-eb8e89a2c8e7.png)
