### PR TITLE
Scenario phases

### DIFF
--- a/src/scenario/scenario.py
+++ b/src/scenario/scenario.py
@@ -113,8 +113,11 @@ class ScenarioGenerator(LocationGenerator):
         model.station.dump_kml(
             self.get_stations(), op.join(meta_dir, 'stations.kml'))
 
-        PhaseMarker.save_markers(
-            self.get_onsets(), op.join(path, 'markers.txt'))
+        markers = self.get_onsets()
+        if markers:
+            PhaseMarker.save_markers(
+                markers, op.join(meta_dir, 'markers.txt'))
+
         dump_readme(path)
 
         def dump_data(gen, *a, **kw):

--- a/src/scenario/scenario.py
+++ b/src/scenario/scenario.py
@@ -86,6 +86,11 @@ class ScenarioGenerator(LocationGenerator):
             self._engine, self.get_sources(), *a, **kw)
 
     @collect
+    def get_onsets(self, tmin=None, tmax=None):
+        return lambda gen, *a, **kw: gen.get_onsets(
+            self._engine, self.get_sources(), *a, **kw)
+
+    @collect
     def get_insar_scenes(self, tmin=None, tmax=None):
         return lambda gen, *a, **kw: gen.get_insar_scenes(
             self._engine, self.get_sources(), *a, **kw)
@@ -107,6 +112,8 @@ class ScenarioGenerator(LocationGenerator):
         model.station.dump_kml(
             self.get_stations(), op.join(meta_dir, 'stations.kml'))
 
+        PhaseMarker.save_markers(
+            self.get_onsets(), op.join(meta_dir, 'markers.txt'))
         dump_readme(path)
 
         def dump_data(gen, *a, **kw):

--- a/src/scenario/scenario.py
+++ b/src/scenario/scenario.py
@@ -114,7 +114,7 @@ class ScenarioGenerator(LocationGenerator):
             self.get_stations(), op.join(meta_dir, 'stations.kml'))
 
         PhaseMarker.save_markers(
-            self.get_onsets(), op.join(meta_dir, 'markers.txt'))
+            self.get_onsets(), op.join(path, 'markers.txt'))
         dump_readme(path)
 
         def dump_data(gen, *a, **kw):

--- a/src/scenario/scenario.py
+++ b/src/scenario/scenario.py
@@ -6,6 +6,7 @@ import os.path as op
 
 from pyrocko.guts import List
 from pyrocko.plot import gmtpy
+from pyrocko.gui.marker import PhaseMarker
 from pyrocko import pile, util, model, config
 from pyrocko.dataset import topo
 

--- a/src/scenario/targets/base.py
+++ b/src/scenario/targets/base.py
@@ -23,6 +23,9 @@ class TargetGenerator(LocationGenerator):
     def get_stations(self):
         return []
 
+    def get_onsets(self, engine, sources, tmin=None, tmax=None):
+        return []
+
     def get_waveforms(self, engine, sources, tmin=None, tmax=None):
         return []
 

--- a/src/scenario/targets/gnss_campaign.py
+++ b/src/scenario/targets/gnss_campaign.py
@@ -72,7 +72,7 @@ class GNSSCampaignGenerator(TargetGenerator):
                 sources,
                 self.get_targets(),
                 nthreads=0)
-        except gf.meta.OutOfBounds as e:
+        except gf.meta.OutOfBounds:
             logger.warning('Could not calculate GNSS displacements'
                            ' - the GF store\'s extend is too small!')
             return []

--- a/src/scenario/targets/insar.py
+++ b/src/scenario/targets/insar.py
@@ -110,8 +110,9 @@ class ScenePatch(Object):
 
     @property
     def width(self):
-        track_shift = num.abs(num.cos(self.inclination*d2r)
-                              * self.track_length)
+        track_shift = num.abs(
+            num.cos(self.inclination*d2r) * self.track_length)
+
         return self.swath_width + track_shift
 
     def get_ll_anchor(self):
@@ -411,7 +412,7 @@ class InSARGenerator(TargetGenerator):
                 sources,
                 self.get_targets(),
                 nthreads=0)
-        except gf.meta.OutOfBounds as e:
+        except gf.meta.OutOfBounds:
             logger.warning('Could not calculate InSAR displacements'
                            ' - the GF store\'s extend is too small!')
             return []

--- a/src/scenario/targets/waveform.py
+++ b/src/scenario/targets/waveform.py
@@ -241,7 +241,7 @@ class WaveformGenerator(TargetGenerator):
             for source in sources:
                 d = source.distance_to(target)
                 for phase in self.tabulated_phases:
-                    t = store.t(phase.definition, (d, source.depth))
+                    t = store.t(phase.definition, (source.depth, d))
                     if not t:
                         continue
                     t += source.time

--- a/src/scenario/targets/waveform.py
+++ b/src/scenario/targets/waveform.py
@@ -224,14 +224,9 @@ class WaveformGenerator(TargetGenerator):
 
         return list(trs.values())
 
-    def get_onsets(self, engine, sources, tmin=None, tmax=None):
+    def get_onsets(self, engine, sources, *args, **kwargs):
         if not self.tabulated_phases:
             return []
-
-        if tmin:
-            sources = [s for s in sources if tmin > s.time]
-        if tmax:
-            sources = [s for s in sources if s.time < tmax]
 
         targets = {t.codes[:3]: t for t in self.get_targets()}
 

--- a/src/scenario/targets/waveform.py
+++ b/src/scenario/targets/waveform.py
@@ -7,7 +7,8 @@ import numpy as num
 from os import path as op
 from functools import reduce
 
-from pyrocko.guts import StringChoice, Float
+from pyrocko.guts import StringChoice, Float, List
+from pyrocko.gui.marker import PhaseMarker
 from pyrocko import gf, model, util, trace, io
 from pyrocko.io_common import FileSaveError
 
@@ -177,6 +178,7 @@ class WaveformGenerator(TargetGenerator):
         return tinc
 
     def get_waveforms(self, engine, sources, tmin=None, tmax=None):
+        print('get waveforms')
         trs = {}
 
         tmin_all, tmax_all = self.get_time_range(sources)
@@ -226,7 +228,14 @@ class WaveformGenerator(TargetGenerator):
         return list(trs.values())
 
     def get_onsets(self, engine, sources, tmin=None, tmax=None):
-        sources = [s for s in sources if tmin>s.time>tmax]
+        if not self.tabulated_phases:
+            return []
+
+        if tmin:
+            sources = [s for s in sources if tmin>s.time]
+        if tmax:
+            sources = [s for s in sources if s.time<tmax]
+
         targets = {t.codes[:3]: t for t in self.get_targets()}
 
         phase_markers = []


### PR DESCRIPTION
Good evening,

It's often handy to have phase markers at hand, also when working with synthetic data. Adding tabulated phases now generates a `markers.txt` file on the fly for the `WaveformGenerator` for all station-source-combinations (given that the underlying earthmodel provides that phase):

    tabulated_phases:
      - !pf.TPDef
        id: S
        definition: 'stored:S'
      - !pf.TPDef
        id: p
        definition: 'cake:p'
