### PR TITLE
gf.seismosizer: fix

### DIFF
--- a/src/gf/seismosizer.py
+++ b/src/gf/seismosizer.py
@@ -4,7 +4,6 @@
 # ---|P------/S----------~Lg----------
 from __future__ import absolute_import, division, print_function
 from builtins import range, map, zip
-from past.builtins import cmp
 
 from collections import defaultdict
 from functools import cmp_to_key
@@ -37,6 +36,10 @@ guts_prefix = 'pf'
 d2r = math.pi / 180.
 
 logger = logging.getLogger('pyrocko.gf.seismosizer')
+
+
+def cmp(x, y):
+    return (x > y) ^ (x < y)
 
 
 def cmp_none_aware(a, b):


### PR DESCRIPTION
Hey,

Seems like since numpy 1.16 the comparison (`cmp`) used in gf.seismosizer triggers a deprecation exception:
```Traceback (most recent call last):
  File "run-example.py", line 73, in <module>
    traces = engine.process(sources=sources, targets=targets)
  File "/usr/local/lib/python3.5/dist-packages/pyrocko/gf/seismosizer.py", line 3181, in process
    skeys = sorted(m.keys(), key=cmp_to_key(cmp_none_aware))
  File "/usr/local/lib/python3.5/dist-packages/pyrocko/gf/seismosizer.py", line 45, in cmp_none_aware
    rv = cmp_none_aware(xa, xb)
  File "/usr/local/lib/python3.5/dist-packages/pyrocko/gf/seismosizer.py", line 45, in cmp_none_aware
    rv = cmp_none_aware(xa, xb)
  File "/usr/local/lib/python3.5/dist-packages/pyrocko/gf/seismosizer.py", line 63, in cmp_none_aware
    return cmp(a, b)
  File "/home/marius/.local/lib/python3.5/site-packages/past/builtins/misc.py", line 29, in cmp
    return (x > y) - (x < y)
TypeError: numpy boolean subtract, the `-` operator, is deprecated, use the bitwise_xor, the `^` operator, or the logical_xor function instead.
```

`cmp` is implemented as:

    return (x > y) - (x < y)

I followed the suggestion in the exception and replaced the `-` operator with `^`. Is this safe?