### PR TITLE
Added obs to TRAINED_MODELS

### DIFF
--- a/src/gui/snuffler/snufflings/seisbench_picker.py
+++ b/src/gui/snuffler/snufflings/seisbench_picker.py
@@ -30,7 +30,7 @@ ML_NETWORKS = (
 )
 TRAINED_MODELS = (
     'original', 'ethz', 'instance', 'scedc', 'stead', 'geofon',
-    'neic', 'cascadia', 'cms', 'jcms', 'jcs', 'jms', 'mexico',
+    'neic', 'obs', 'cascadia', 'cms', 'jcms', 'jcs', 'jms', 'mexico',
     'nankai', 'san_andreas'
 )
 


### PR DESCRIPTION
This works for PhaseNet and EQ-Transformer and is basically adding 'PickBlue' to the models, since PickBlue in seisbench is just returning PhaseNet or EQ-Transformer trained on obs.