### PR TITLE
marker phasename includes certainty for ml_pickers

### DIFF
--- a/src/gui/snuffler/snufflings/seisbench_picker.py
+++ b/src/gui/snuffler/snufflings/seisbench_picker.py
@@ -339,7 +339,7 @@ class SeisBenchDetector(Snuffling):
                         tmin=tpeak,
                         tmax=tpeak,
                         kind=0 if pick.phase == 'P' else 1,
-                        phasename=pick.phase,
+                        phasename=f'{pick.phase}{pick.peak_value:.2f}',
                         incidence_angle=pick.peak_value,
                     ))
 


### PR DESCRIPTION
This includes the certainty of the pick in the phasename, which us then displayed in the marker list and the marker annotation within the stream view.